### PR TITLE
Support for file rename callback

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
 
     async.eachLimit(this.files, options.limit, function (el, next) {
       var rootdir = path.dirname(el.src);
-      var pngFile = path.basename(el.src, ".svg") + ".png";
+      var pngFile = typeof el.orig.rename === 'function' ? el.dest : path.basename(el.src, ".svg") + ".png";
       var dest = path.join(rootdir, options.subdir, pngFile);
 
       svg2png(el.src, dest, options.scale, function (err) {


### PR DESCRIPTION
I needed rename support. Here's my case:

``` js
svg2png: {
      stackmap: {
        options: {
          subdir: '..'
        },
        files: [
          {
            expand: true,
            src: ['**/*.svg'],
            dest: '<%= config.imgSourceDir %>',
            cwd: '<%= config.imgSourceDir %>/stackmap',
            rename: function(dest, src) {
              return src.replace(/([^\/]+)\.svg$/i, function($0, $1) {
                return 'stackmap.svg.' + $1 + '.png';
              });
            }
          }
        ]
      }
    }
```

Opened for discussion.
