### PR TITLE
Fixes #3 - Path must be a string

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -17,8 +17,8 @@ module.exports = function (grunt) {
     });
 
     async.eachLimit(this.files, options.limit, function (el, next) {
-      var rootdir = path.dirname(el.src);
-      var pngFile = path.basename(el.src, ".svg") + ".png";
+      var rootdir = path.dirname(String(el.src));
+      var pngFile = path.basename(String(el.src), ".svg") + ".png";
       var dest = path.join(rootdir, options.subdir, pngFile);
 
       svg2png(el.src, dest, options.scale, function (err) {


### PR DESCRIPTION
Was getting an error that the parameter to path.dirname and path.basename must be a string.
